### PR TITLE
feat: do not check existence of erc721

### DIFF
--- a/contracts/Web3EntryBase.sol
+++ b/contracts/Web3EntryBase.sol
@@ -248,7 +248,6 @@ contract Web3EntryBase is
 
     function linkERC721(DataTypes.linkERC721Data calldata vars) external override {
         _validateCallerPermission(vars.fromCharacterId, OP.LINK_ERC721);
-        _validateERC721Exists(vars.tokenAddress, vars.tokenId);
 
         LinkLogic.linkERC721(vars, _linklist, _attachedLinklists);
     }
@@ -567,7 +566,6 @@ contract Web3EntryBase is
         DataTypes.ERC721Struct calldata erc721
     ) external override returns (uint256) {
         _validateCallerPermission(vars.characterId, OP.POST_NOTE_FOR_ERC721);
-        _validateERC721Exists(erc721.tokenAddress, erc721.erc721TokenId);
 
         bytes32 linkItemType = Constants.LINK_ITEM_TYPE_ERC721;
         uint256 noteId = _nextNoteId(vars.characterId);
@@ -944,11 +942,6 @@ contract Web3EntryBase is
 
     function _validateCharacterExists(uint256 characterId) internal view {
         if (!_exists(characterId)) revert ErrCharacterNotExists(characterId);
-    }
-
-    function _validateERC721Exists(address tokenAddress, uint256 tokenId) internal view {
-        address owner = IERC721(tokenAddress).ownerOf(tokenId);
-        if (address(0) == owner) revert ErrREC721NotExists();
     }
 
     function _validateNoteExists(uint256 characterId, uint256 noteId) internal view {

--- a/contracts/libraries/Error.sol
+++ b/contracts/libraries/Error.sol
@@ -35,9 +35,6 @@ error ErrNotEnoughPermissionForThisNote();
 /// @dev Target address already has primary character
 error ErrTargetAlreadyHasPrimaryCharacter();
 
-/// @dev ERC721 token does not exist
-error ErrREC721NotExists();
-
 /// @dev Note has been deleted
 error ErrNoteIsDeleted();
 

--- a/test/Note.t.sol
+++ b/test/Note.t.sol
@@ -438,14 +438,6 @@ contract NoteTest is Test, SetUp, Utils {
             makePostNoteData(Const.FIRST_CHARACTER_ID),
             DataTypes.ERC721Struct(address(nft), 1)
         );
-
-        // REC721NotExists
-        vm.expectRevert(abi.encodePacked("ERC721: owner query for nonexistent token"));
-        vm.prank(alice);
-        web3Entry.postNote4ERC721(
-            makePostNoteData(Const.FIRST_CHARACTER_ID),
-            DataTypes.ERC721Struct(address(nft), 1)
-        );
     }
 
     function testPostNote4AnyUri() public {

--- a/test/links/LinkERC721.t.sol
+++ b/test/links/LinkERC721.t.sol
@@ -22,8 +22,9 @@ contract LinkERC721Test is Test, SetUp, Utils {
 
     // solhint-disable-next-line function-max-lines
     function testLinkERC721() public {
-        vm.prank(address(web3Entry));
+        // mint an nft
         nft.mint(bob);
+
         vm.prank(alice);
         expectEmit(CheckTopic1 | CheckTopic2 | CheckTopic3 | CheckData);
         emit Events.LinkERC721(Const.FIRST_CHARACTER_ID, address(nft), 1, Const.LikeLinkType, 1);
@@ -78,7 +79,7 @@ contract LinkERC721Test is Test, SetUp, Utils {
     }
 
     function testLinkERC721Fail() public {
-        // case 1: NotEnoughPermission
+        //  NotEnoughPermission
         vm.prank(bob);
         vm.expectRevert(abi.encodeWithSelector(ErrNotEnoughPermission.selector));
         web3Entry.linkERC721(
@@ -90,24 +91,11 @@ contract LinkERC721Test is Test, SetUp, Utils {
                 new bytes(0)
             )
         );
-
-        // case 2: ErrREC721NotExists
-        vm.prank(alice);
-        vm.expectRevert(abi.encodePacked("ERC721: owner query for nonexistent token"));
-        web3Entry.linkERC721(
-            DataTypes.linkERC721Data(
-                Const.FIRST_CHARACTER_ID,
-                address(nft),
-                2,
-                Const.LikeLinkType,
-                new bytes(0)
-            )
-        );
     }
 
     function testUnlinkERC721() public {
-        vm.prank(address(web3Entry));
         nft.mint(bob);
+
         vm.startPrank(alice);
         web3Entry.linkERC721(
             DataTypes.linkERC721Data(


### PR DESCRIPTION

### Description

do not check existence of erc721 for linkERC721 and postNote4ERC721


### Checklist
- [ ] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [ ] I have updated the abi and docs
- [x] I tested locally to make sure this feature/fix works
