### PR TITLE
feat: use oz lib to avoid malleability for ecrecover

### DIFF
--- a/contracts/misc/NewbieVilla.sol
+++ b/contracts/misc/NewbieVilla.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.16;
 import "../interfaces/IWeb3Entry.sol";
 import "../libraries/OP.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/token/ERC777/IERC777Recipient.sol";
@@ -110,13 +111,13 @@ contract NewbieVilla is Initializable, AccessControlEnumerable, IERC721Receiver,
         uint256 characterId,
         uint256 nonce,
         uint256 expires,
-        bytes memory proof
+        bytes calldata proof
     ) external notExpired(expires) {
-        bytes32 signedData = _prefixed(
+        bytes32 signedData = ECDSA.toEthSignedMessageHash(
             keccak256(abi.encodePacked(address(this), characterId, nonce, expires))
         );
         require(
-            hasRole(ADMIN_ROLE, _recoverSigner(signedData, proof)),
+            hasRole(ADMIN_ROLE, ECDSA.recover(signedData, proof)),
             "NewbieVilla: unauthorized withdraw"
         );
 
@@ -217,34 +218,5 @@ contract NewbieVilla is Initializable, AccessControlEnumerable, IERC721Receiver,
      */
     function getToken() external view returns (address) {
         return _token;
-    }
-
-    function _splitSignature(
-        bytes memory sig
-    ) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
-        require(sig.length == 65, "NewbieVilla: wrong signature length");
-
-        /* solhint-disable no-inline-assembly */
-        assembly {
-            // first 32 bytes, after the length prefix.
-            r := mload(add(sig, 32))
-            // second 32 bytes.
-            s := mload(add(sig, 64))
-            // final byte (first byte of the next 32 bytes).
-            v := byte(0, mload(add(sig, 96)))
-        }
-        /* solhint-enable no-inline-assembly */
-
-        return (v, r, s);
-    }
-
-    function _recoverSigner(bytes32 message, bytes memory sig) internal pure returns (address) {
-        (uint8 v, bytes32 r, bytes32 s) = _splitSignature(sig);
-
-        return ecrecover(message, v, r, s);
-    }
-
-    function _prefixed(bytes32 hash) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
     }
 }

--- a/test/links/LinkLinklist.t.sol
+++ b/test/links/LinkLinklist.t.sol
@@ -87,6 +87,7 @@ contract LinkLinklistTest is Test, SetUp, Utils {
         );
     }
 
+    // solhint-disable-next-line function-max-lines
     function testUnlinkLinklist() public {
         vm.startPrank(alice);
         web3Entry.linkLinklist(
@@ -123,7 +124,7 @@ contract LinkLinklistTest is Test, SetUp, Utils {
             )
         );
 
-       // unlink a non-existing character
+        // unlink a non-existing character
         web3Entry.unlinkLinklist(
             DataTypes.unlinkLinklistData(
                 Const.FIRST_CHARACTER_ID,

--- a/test/misc/NewbieVilla.t.sol
+++ b/test/misc/NewbieVilla.t.sol
@@ -18,7 +18,8 @@ contract NewbieVillaTest is Test, SetUp, Utils {
         token.mint(alice, 10 ether);
         token.mint(bob, 10 ether);
 
-        // grant mint role to alice
+        // grant mint role to alice, so alice will be the admin and all characters created by
+        // email users will be owned by alice for custodian.
         vm.prank(newbieAdmin);
         newbieVilla.grantRole(ADMIN_ROLE, alice);
     }
@@ -47,8 +48,9 @@ contract NewbieVillaTest is Test, SetUp, Utils {
 
         // check operators
         address[] memory operators = web3Entry.getOperators(Const.FIRST_CHARACTER_ID);
-        assertEq(operators[0], alice);
+        assertEq(operators[0], alice); // msg.sender will be granted as operator
         assertEq(operators[1], xsyncOperator);
+        assertEq(operators.length, 2);
 
         // check operator permission bitmap
         assertEq(
@@ -87,10 +89,12 @@ contract NewbieVillaTest is Test, SetUp, Utils {
         assertEq(operators[1], xsyncOperator);
 
         // check operator permission bitmap
+        // alice(NewbieVilla admin) has DEFAULT_PERMISSION_BITMAP.
         assertEq(
             web3Entry.getOperatorPermissions(Const.FIRST_CHARACTER_ID, alice),
             OP.DEFAULT_PERMISSION_BITMAP
         );
+        // xsyncOperator has POST_NOTE_DEFAULT_PERMISSION_BITMAP
         assertEq(
             web3Entry.getOperatorPermissions(Const.FIRST_CHARACTER_ID, xsyncOperator),
             OP.POST_NOTE_DEFAULT_PERMISSION_BITMAP
@@ -115,7 +119,8 @@ contract NewbieVillaTest is Test, SetUp, Utils {
         nft.safeTransferFrom(address(bob), address(newbieVilla), Const.FIRST_CHARACTER_ID);
     }
 
-    function testWithdrawNewbieOut() public {
+    function testWithdrawNewbieOut(uint256 amount) public {
+        vm.assume(amount > 0 && amount < 10 ether);
         address to = carol;
         uint256 characterId = Const.FIRST_CHARACTER_ID;
         uint256 nonce = 1;

--- a/test/misc/NewbieVilla.t.sol
+++ b/test/misc/NewbieVilla.t.sol
@@ -125,7 +125,6 @@ contract NewbieVillaTest is Test, SetUp, Utils {
         uint256 characterId = Const.FIRST_CHARACTER_ID;
         uint256 nonce = 1;
         uint256 expires = block.timestamp + 10 minutes;
-        uint256 amount = 1 ether;
 
         // 1. create and transfer web3Entry nft to newbieVilla
         web3Entry.createCharacter(makeCharacterData(Const.MOCK_CHARACTER_HANDLE, newbieAdmin));


### PR DESCRIPTION
use oz ECDSA lib to avoid malleability for ecrecover when withdrawing email user's characters

### Description

### Checklist
- [ ] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [ ] I have updated the abi and docs
- [ ] I tested locally to make sure this feature/fix works
