### PR TITLE
Add burnLinklist for web3Entry contract

### DIFF
--- a/contracts/Linklist.sol
+++ b/contracts/Linklist.sol
@@ -10,7 +10,6 @@ import {DataTypes} from "./libraries/DataTypes.sol";
 import {
     ErrCallerNotWeb3Entry,
     ErrCallerNotWeb3EntryOrNotOwner,
-    ErrNotOwner,
     ErrTokenNotExists
 } from "./libraries/Error.sol";
 import {LinklistStorage} from "./storage/LinklistStorage.sol";
@@ -38,7 +37,11 @@ contract Linklist is
 
     modifier onlyWeb3Entry() {
         if (msg.sender != Web3Entry) revert ErrCallerNotWeb3Entry();
+        _;
+    }
 
+    modifier onlyExistingToken(uint256 tokenId) {
+        if (0 == _linklistOwners[tokenId]) revert ErrTokenNotExists();
         _;
     }
 
@@ -90,7 +93,10 @@ contract Linklist is
     }
 
     /// @inheritdoc ILinklist
-    function setUri(uint256 tokenId, string memory newUri) external override {
+    function setUri(
+        uint256 tokenId,
+        string memory newUri
+    ) external override onlyExistingToken(tokenId) {
         // caller must be web3Entry or owner
         if (msg.sender != Web3Entry && msg.sender != ownerOf(tokenId))
             revert ErrCallerNotWeb3EntryOrNotOwner();
@@ -251,19 +257,21 @@ contract Linklist is
     /// @inheritdoc ILinklist
     function getLinkingCharacterIds(
         uint256 tokenId
-    ) external view override returns (uint256[] memory) {
+    ) external view override onlyExistingToken(tokenId) returns (uint256[] memory) {
         return _linkingCharacters[tokenId].values();
     }
 
     /// @inheritdoc ILinklist
     function getLinkingCharacterListLength(
         uint256 tokenId
-    ) external view override returns (uint256) {
+    ) external view override onlyExistingToken(tokenId) returns (uint256) {
         return _linkingCharacters[tokenId].length();
     }
 
     /// @inheritdoc ILinklist
-    function getOwnerCharacterId(uint256 tokenId) external view override returns (uint256) {
+    function getOwnerCharacterId(
+        uint256 tokenId
+    ) external view override onlyExistingToken(tokenId) returns (uint256) {
         uint256 characterId = _linklistOwners[tokenId];
         return characterId;
     }
@@ -271,7 +279,13 @@ contract Linklist is
     /// @inheritdoc ILinklist
     function getLinkingNotes(
         uint256 tokenId
-    ) external view override returns (DataTypes.NoteStruct[] memory results) {
+    )
+        external
+        view
+        override
+        onlyExistingToken(tokenId)
+        returns (DataTypes.NoteStruct[] memory results)
+    {
         bytes32[] memory linkKeys = _linkNoteKeys[tokenId].values();
         results = new DataTypes.NoteStruct[](linkKeys.length);
         for (uint256 i = 0; i < linkKeys.length; i++) {
@@ -288,14 +302,22 @@ contract Linklist is
     }
 
     /// @inheritdoc ILinklist
-    function getLinkingNoteListLength(uint256 tokenId) external view override returns (uint256) {
+    function getLinkingNoteListLength(
+        uint256 tokenId
+    ) external view override onlyExistingToken(tokenId) returns (uint256) {
         return _linkNoteKeys[tokenId].length();
     }
 
     /// @inheritdoc ILinklist
     function getLinkingERC721s(
         uint256 tokenId
-    ) external view override returns (DataTypes.ERC721Struct[] memory results) {
+    )
+        external
+        view
+        override
+        onlyExistingToken(tokenId)
+        returns (DataTypes.ERC721Struct[] memory results)
+    {
         bytes32[] memory linkKeys = _linkingERC721Keys[tokenId].values();
         results = new DataTypes.ERC721Struct[](linkKeys.length);
         for (uint256 i = 0; i < linkKeys.length; i++) {
@@ -312,26 +334,30 @@ contract Linklist is
     }
 
     /// @inheritdoc ILinklist
-    function getLinkingERC721ListLength(uint256 tokenId) external view override returns (uint256) {
+    function getLinkingERC721ListLength(
+        uint256 tokenId
+    ) external view override onlyExistingToken(tokenId) returns (uint256) {
         return _linkingERC721Keys[tokenId].length();
     }
 
     /// @inheritdoc ILinklist
     function getLinkingAddresses(
         uint256 tokenId
-    ) external view override returns (address[] memory) {
+    ) external view override onlyExistingToken(tokenId) returns (address[] memory) {
         return _linkingAddresses[tokenId].values();
     }
 
     /// @inheritdoc ILinklist
-    function getLinkingAddressListLength(uint256 tokenId) external view override returns (uint256) {
+    function getLinkingAddressListLength(
+        uint256 tokenId
+    ) external view override onlyExistingToken(tokenId) returns (uint256) {
         return _linkingAddresses[tokenId].length();
     }
 
     /// @inheritdoc ILinklist
     function getLinkingAnyUris(
         uint256 tokenId
-    ) external view override returns (string[] memory results) {
+    ) external view override onlyExistingToken(tokenId) returns (string[] memory results) {
         bytes32[] memory linkKeys = _linkingAnyKeys[tokenId].values();
         results = new string[](linkKeys.length);
         for (uint256 i = 0; i < linkKeys.length; i++) {
@@ -348,24 +374,28 @@ contract Linklist is
     /// @inheritdoc ILinklist
     function getLinkingAnyUriKeys(
         uint256 tokenId
-    ) external view override returns (bytes32[] memory) {
+    ) external view override onlyExistingToken(tokenId) returns (bytes32[] memory) {
         return _linkingAnyKeys[tokenId].values();
     }
 
     /// @inheritdoc ILinklist
-    function getLinkingAnyListLength(uint256 tokenId) external view override returns (uint256) {
+    function getLinkingAnyListLength(
+        uint256 tokenId
+    ) external view override onlyExistingToken(tokenId) returns (uint256) {
         return _linkingAnyKeys[tokenId].length();
     }
 
     /// @inheritdoc ILinklist
     function getLinkingLinklistIds(
         uint256 tokenId
-    ) external view override returns (uint256[] memory) {
+    ) external view override onlyExistingToken(tokenId) returns (uint256[] memory) {
         return _linkingLinklists[tokenId].values();
     }
 
     /// @inheritdoc ILinklist
-    function getLinkingLinklistLength(uint256 tokenId) external view override returns (uint256) {
+    function getLinkingLinklistLength(
+        uint256 tokenId
+    ) external view override onlyExistingToken(tokenId) returns (uint256) {
         return _linkingLinklists[tokenId].length();
     }
 
@@ -376,15 +406,17 @@ contract Linklist is
     function getCurrentTakeOver(uint256 tokenId) external view override returns (uint256) {}
 
     /// @inheritdoc ILinklist
-    function getLinkType(uint256 tokenId) external view override returns (bytes32) {
+    function getLinkType(
+        uint256 tokenId
+    ) external view override onlyExistingToken(tokenId) returns (bytes32) {
         return _linkTypes[tokenId];
     }
 
     // slither-disable-start naming-convention
     // solhint-disable-next-line func-name-mixedcase
-    function Uri(uint256 tokenId) external view override returns (string memory) {
-        if (0 == _linklistOwners[tokenId]) revert ErrTokenNotExists();
-
+    function Uri(
+        uint256 tokenId
+    ) external view override onlyExistingToken(tokenId) returns (string memory) {
         return _uris[tokenId];
     }
 

--- a/contracts/Linklist.sol
+++ b/contracts/Linklist.sol
@@ -423,7 +423,9 @@ contract Linklist is
     // slither-disable-end naming-convention
 
     /// @inheritdoc ILinklist
-    function characterOwnerOf(uint256 tokenId) external view override returns (uint256) {
+    function characterOwnerOf(
+        uint256 tokenId
+    ) external view override onlyExistingToken(tokenId) returns (uint256) {
         return _linklistOwners[tokenId];
     }
 
@@ -442,7 +444,9 @@ contract Linklist is
     }
 
     /// @inheritdoc ERC721
-    function ownerOf(uint256 tokenId) public view override(ERC721) returns (address) {
+    function ownerOf(
+        uint256 tokenId
+    ) public view override(ERC721) onlyExistingToken(tokenId) returns (address) {
         uint256 characterId = _linklistOwners[tokenId];
         address owner = IERC721(Web3Entry).ownerOf(characterId);
         return owner;

--- a/contracts/Web3EntryBase.sol
+++ b/contracts/Web3EntryBase.sol
@@ -28,7 +28,8 @@ import {
     ErrHandleLengthInvalid,
     ErrHandleContainsInvalidCharacters,
     ErrSignatureExpired,
-    ErrSignatureInvalid
+    ErrSignatureInvalid,
+    ErrTokenNotExists
 } from "./libraries/Error.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
@@ -48,6 +49,11 @@ contract Web3EntryBase is
 
     // solhint-disable-next-line private-vars-leading-underscore
     uint256 internal constant REVISION = 4;
+
+    modifier onlyExistingToken(uint256 tokenId) {
+        if (!_exists(tokenId)) revert ErrTokenNotExists();
+        _;
+    }
 
     /// @inheritdoc IWeb3Entry
     function initialize(
@@ -683,7 +689,7 @@ contract Web3EntryBase is
     /// @inheritdoc IWeb3Entry
     function getCharacter(
         uint256 characterId
-    ) external view override returns (DataTypes.Character memory) {
+    ) external view override onlyExistingToken(characterId) returns (DataTypes.Character memory) {
         return _characterById[characterId];
     }
 
@@ -697,7 +703,9 @@ contract Web3EntryBase is
     }
 
     /// @inheritdoc IWeb3Entry
-    function getHandle(uint256 characterId) external view override returns (string memory) {
+    function getHandle(
+        uint256 characterId
+    ) external view override onlyExistingToken(characterId) returns (string memory) {
         return _characterById[characterId].handle;
     }
 
@@ -773,7 +781,9 @@ contract Web3EntryBase is
      * @param characterId The character ID to query.
      * @return The token URI.
      */
-    function tokenURI(uint256 characterId) public view override returns (string memory) {
+    function tokenURI(
+        uint256 characterId
+    ) public view override onlyExistingToken(characterId) returns (string memory) {
         return _characterById[characterId].uri;
     }
 

--- a/contracts/Web3EntryBase.sol
+++ b/contracts/Web3EntryBase.sol
@@ -625,6 +625,20 @@ contract Web3EntryBase is
     }
 
     /// @inheritdoc IWeb3Entry
+    function burnLinklist(uint256 linklistId) external override {
+        // only the owner of the character can burn the linklist through web3Entry contract
+        uint256 characterId = ILinklist(_linklist).getOwnerCharacterId(linklistId);
+        if (msg.sender != ownerOf(characterId)) revert ErrNotCharacterOwner();
+
+        // delete _attachedLinklist
+        bytes32 linkType = ILinklist(_linklist).getLinkType(linklistId);
+        delete _attachedLinklists[characterId][linkType];
+
+        // burn linklist
+        ILinklist(_linklist).burn(linklistId);
+    }
+
+    /// @inheritdoc IWeb3Entry
     function getOperators(uint256 characterId) external view override returns (address[] memory) {
         return _operatorsByCharacter[characterId].values();
     }

--- a/contracts/interfaces/ILinklist.sol
+++ b/contracts/interfaces/ILinklist.sol
@@ -27,6 +27,7 @@ interface ILinklist {
 
     /**
      * @notice Burns a Linklist NFT.
+     * @dev Only web3Entry can burn the Linklist NFT.
      * @param tokenId The token ID to burn.
      */
     function burn(uint256 tokenId) external;

--- a/contracts/interfaces/IWeb3Entry.sol
+++ b/contracts/interfaces/IWeb3Entry.sol
@@ -423,6 +423,12 @@ interface IWeb3Entry {
     ) external returns (uint256);
 
     /**
+     * @notice Burns a linklist NFT.
+     * @param linklistId The linklist ID to burn.
+     */
+    function burnLinklist(uint256 linklistId) external;
+
+    /**
      * @notice Get operator list of a character. This operator list has only a sole purpose, which is
      * keeping records of keys of `operatorsPermissionBitMap`. Thus, addresses queried by this function
      * not always have operator permissions. Keep in mind don't use this function to check

--- a/contracts/libraries/Error.sol
+++ b/contracts/libraries/Error.sol
@@ -79,3 +79,6 @@ error ErrSignatureInvalid();
 
 /// @dev Caller not owner
 error ErrNotOwner();
+
+/// @dev Token not exists
+error ErrTokenNotExists();

--- a/contracts/storage/LinklistExtendStorage.sol
+++ b/contracts/storage/LinklistExtendStorage.sol
@@ -4,11 +4,8 @@ pragma solidity 0.8.18;
 
 contract LinklistExtendStorage {
     uint256 internal _tokenCount;
-
-    // tokenId => characterId
-    mapping(uint256 => uint256) internal _linklistOwners;
-    // characterId => balances
-    mapping(uint256 => uint256) internal _linklistBalances;
+    mapping(uint256 tokenId => uint256 characterId) internal _linklistOwners;
+    mapping(uint256 characterId => uint256 balances) internal _linklistBalances;
     uint256 internal _totalSupply;
 }
 // slither-disable-end naming-convention

--- a/test/Characters/CreateCharacter.t.sol
+++ b/test/Characters/CreateCharacter.t.sol
@@ -170,4 +170,9 @@ contract CreateCharacterTest is CommonTest {
         assertEq(web3Entry.tokenByIndex(1), SECOND_CHARACTER_ID);
         assertEq(web3Entry.tokenByIndex(2), 4);
     }
+
+    function testBurnFailWithTokenNotExists() public {
+        vm.expectRevert("ERC721: operator query for nonexistent token");
+        web3Entry.burn(3);
+    }
 }

--- a/test/UpgradeLinklist.t.sol
+++ b/test/UpgradeLinklist.t.sol
@@ -85,7 +85,7 @@ contract UpgradeLinklistTest is CommonTest {
         uint256 tokenId = Linklist(_linklist).mint(FIRST_CHARACTER_ID, FollowLinkType);
         assertEq(totalSupply + 1, Linklist(_linklist).totalSupply());
         // burn a linklist
-        vm.prank(Linklist(_linklist).ownerOf(tokenId));
+        vm.prank(_web3Entry);
         Linklist(_linklist).burn(tokenId);
         // check totalSupply
         assertEq(totalSupply, Linklist(_linklist).totalSupply());

--- a/test/Web3Entry.t.sol
+++ b/test/Web3Entry.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.18;
 
 import {CommonTest} from "./helpers/CommonTest.sol";
+import {ErrTokenNotExists} from "../contracts/libraries/Error.sol";
 import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {
@@ -27,5 +28,22 @@ contract CharacterSettingsTest is CommonTest {
         assertTrue(web3Entry.supportsInterface(type(IERC721Enumerable).interfaceId));
         assertTrue(web3Entry.supportsInterface(type(IERC721Metadata).interfaceId));
         assertTrue(web3Entry.supportsInterface(type(IERC165).interfaceId));
+    }
+
+    function testQueryWithTokenNotExists() public {
+        // token not exist
+        uint256 tokenId = 2;
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        web3Entry.tokenURI(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        web3Entry.getHandle(tokenId);
+
+        vm.expectRevert("ERC721: owner query for nonexistent token");
+        web3Entry.ownerOf(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        web3Entry.getCharacter(tokenId);
     }
 }

--- a/test/links/Linklist.t.sol
+++ b/test/links/Linklist.t.sol
@@ -6,7 +6,6 @@ import {
     ErrNotEnoughPermission,
     ErrCallerNotWeb3EntryOrNotOwner,
     ErrCallerNotWeb3Entry,
-    ErrNotOwner,
     ErrTokenNotExists,
     ErrNotCharacterOwner
 } from "../../contracts/libraries/Error.sol";
@@ -131,16 +130,71 @@ contract LinklistTest is CommonTest {
             )
         );
 
-        // bob sets linklist uri
+        // case 1: caller not web3Entry or not owner
         vm.expectRevert(abi.encodeWithSelector(ErrCallerNotWeb3EntryOrNotOwner.selector));
         vm.prank(bob);
         linklist.setUri(1, TOKEN_URI);
+
+        // case 2: token not exist
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        vm.prank(address(web3Entry));
+        linklist.setUri(2, TOKEN_URI);
     }
 
     function testUriFail() public {
         // token not exist
         vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
         linklist.Uri(2);
+    }
+
+    function testQueryWithTokenNotExists() public {
+        // token not exist
+        uint256 tokenId = 2;
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.getLinkingCharacterIds(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.getLinkingCharacterListLength(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.getOwnerCharacterId(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.getLinkingNotes(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.getLinkingERC721s(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.getLinkingERC721ListLength(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.getLinkingAddresses(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.getLinkingAddressListLength(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.getLinkingAnyUris(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.getLinkingAnyUriKeys(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.getLinkingAnyListLength(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.getLinkingLinklistIds(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.getLinkingLinklistLength(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.getLinkType(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.Uri(tokenId);
     }
 
     function testMintFuzz(uint256 amount) public {
@@ -243,6 +297,8 @@ contract LinklistTest is CommonTest {
         assertEq(linklist.balanceOf(alice), 0);
         assertEq(linklist.totalSupply(), 0);
         assertEq(web3Entry.getLinklistId(1, FollowLinkType), 0);
+        // query linkType error
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
         assertEq(web3Entry.getLinklistType(1), bytes32Zero);
 
         // link character
@@ -269,7 +325,7 @@ contract LinklistTest is CommonTest {
         web3Entry.burnLinklist(1);
 
         // case 2: linklist not exist
-        vm.expectRevert("ERC721: owner query for nonexistent token");
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
         web3Entry.burnLinklist(100);
     }
 }

--- a/test/links/Linklist.t.sol
+++ b/test/links/Linklist.t.sol
@@ -195,6 +195,12 @@ contract LinklistTest is CommonTest {
 
         vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
         linklist.Uri(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.characterOwnerOf(tokenId);
+
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.ownerOf(tokenId);
     }
 
     function testMintFuzz(uint256 amount) public {

--- a/test/links/Linklist.t.sol
+++ b/test/links/Linklist.t.sol
@@ -6,7 +6,8 @@ import {
     ErrNotEnoughPermission,
     ErrCallerNotWeb3EntryOrNotOwner,
     ErrCallerNotWeb3Entry,
-    ErrNotOwner
+    ErrNotOwner,
+    ErrTokenNotExists
 } from "../../contracts/libraries/Error.sol";
 import {CommonTest} from "../helpers/CommonTest.sol";
 import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
@@ -19,7 +20,7 @@ import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 contract LinklistTest is CommonTest {
     event Transfer(address indexed from, uint256 indexed characterId, uint256 indexed tokenId);
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
-    event Burn(address indexed from, uint256 indexed characterId, uint256 indexed tokenId);
+    event Burn(uint256 indexed from, uint256 indexed tokenId);
 
     /* solhint-disable comprehensive-interface */
     function setUp() public {
@@ -135,6 +136,11 @@ contract LinklistTest is CommonTest {
         linklist.setUri(1, TOKEN_URI);
     }
 
+    function testUri() public {
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        linklist.Uri(2);
+    }
+
     function testMintFuzz(uint256 amount) public {
         vm.assume(amount > 0);
         vm.assume(amount < 100);
@@ -158,13 +164,13 @@ contract LinklistTest is CommonTest {
     }
 
     function testBurn() public {
-        vm.prank(address(web3Entry));
+        vm.startPrank(address(web3Entry));
         linklist.mint(FIRST_CHARACTER_ID, FollowLinkType);
 
         expectEmit(CheckAll);
-        emit Burn(alice, FIRST_CHARACTER_ID, FIRST_LINKLIST_ID);
-        vm.prank(alice);
+        emit Burn(FIRST_CHARACTER_ID, FIRST_LINKLIST_ID);
         linklist.burn(1);
+        vm.stopPrank();
 
         // check balances
         assertEq(linklist.balanceOf(FIRST_CHARACTER_ID), 0);
@@ -177,12 +183,13 @@ contract LinklistTest is CommonTest {
         vm.prank(address(web3Entry));
         linklist.mint(FIRST_CHARACTER_ID, FollowLinkType);
 
-        // case 1: caller not owner
-        vm.expectRevert(abi.encodeWithSelector(ErrNotOwner.selector));
+        // case 1: caller not web3Entry
+        vm.expectRevert(abi.encodeWithSelector(ErrCallerNotWeb3Entry.selector));
         linklist.burn(1);
 
         // case 2: token not exist
-        vm.expectRevert("ERC721: owner query for nonexistent token");
+        vm.expectRevert(abi.encodeWithSelector(ErrTokenNotExists.selector));
+        vm.prank(address(web3Entry));
         linklist.burn(2);
     }
 
@@ -191,9 +198,9 @@ contract LinklistTest is CommonTest {
         uint256 mintAmount = amount;
         uint256 burnAmount = amount / 2;
 
+        vm.startPrank(address(web3Entry));
         // mint linklist
         for (uint256 i = 0; i < mintAmount; i++) {
-            vm.prank(address(web3Entry));
             linklist.mint(FIRST_CHARACTER_ID, FollowLinkType);
         }
         // check balances
@@ -204,14 +211,46 @@ contract LinklistTest is CommonTest {
 
         // burn linklist
         for (uint256 i = 1; i <= burnAmount; i++) {
-            vm.prank(alice);
             linklist.burn(i);
         }
+        vm.stopPrank();
+
         // check balances
         uint256 leftAmount = mintAmount - burnAmount;
         assertEq(linklist.balanceOf(FIRST_CHARACTER_ID), leftAmount);
         assertEq(linklist.balanceOf(alice), leftAmount);
         // check totalSupply
         assertEq(linklist.totalSupply(), mintAmount - burnAmount);
+    }
+
+    function testBurnLinklistByWeb3Entry() public {
+        vm.startPrank(alice);
+        // link character
+        web3Entry.linkCharacter(DataTypes.linkCharacterData(1, 2, FollowLinkType, ""));
+        // check
+        assertEq(linklist.balanceOf(1), 1);
+        assertEq(linklist.balanceOf(alice), 1);
+        assertEq(linklist.totalSupply(), 1);
+        assertEq(web3Entry.getLinklistId(1, FollowLinkType), 1);
+        assertEq(web3Entry.getLinklistType(1), FollowLinkType);
+
+        // burn linklist
+        web3Entry.burnLinklist(1);
+        // check linklist 1
+        assertEq(linklist.balanceOf(1), 0);
+        assertEq(linklist.balanceOf(alice), 0);
+        assertEq(linklist.totalSupply(), 0);
+        assertEq(web3Entry.getLinklistId(1, FollowLinkType), 0);
+        assertEq(web3Entry.getLinklistType(1), bytes32Zero);
+
+        // link character
+        // check linklist 2
+        web3Entry.linkCharacter(DataTypes.linkCharacterData(1, 2, FollowLinkType, ""));
+        assertEq(linklist.balanceOf(1), 1);
+        assertEq(linklist.balanceOf(alice), 1);
+        assertEq(linklist.totalSupply(), 1);
+        assertEq(web3Entry.getLinklistId(1, FollowLinkType), 2);
+        assertEq(web3Entry.getLinklistType(2), FollowLinkType);
+        vm.stopPrank();
     }
 }


### PR DESCRIPTION
### Description

1. Add `burnLinklist` for  web3Entry contract to burn a linklist
2. Add `onlyExistingToken` modifier for query functions of linklist contract

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] I have updated the abi and docs
- [x] I tested locally to make sure this feature/fix works

###  Which contracts need to be upgraded ?
- [x] Web3Entry
- [x] Linklist
- [ ] NewbieVilla
- [ ] Tips
- [ ] ApprovalMintModule
- [ ] LimitedMintModule
- [ ] MintNFT template
